### PR TITLE
fix: frp v0.67.0+ requires build with make and npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM golang:alpine as build
 RUN apk add --no-cache patch make nodejs npm
-RUN apk add --no-cache patch
 WORKDIR frp
 ARG VERSION=0.67.0
 RUN wget -qO- https://github.com/fatedier/frp/archive/refs/tags/v${VERSION}.tar.gz | tar -xz --strip-components 1
 ADD patches patches
 RUN patch -p1 < patches/udp-proxy-fly-global-services.patch
 RUN patch -p1 < patches/kcp-quic-fly-global-services.patch
-
 RUN cd web/frps && npm install && npm run build
 RUN make frps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM golang:alpine as build
+RUN apk add --no-cache patch make nodejs npm
 RUN apk add --no-cache patch
 WORKDIR frp
-ARG VERSION=0.61.0
+ARG VERSION=0.67.0
 RUN wget -qO- https://github.com/fatedier/frp/archive/refs/tags/v${VERSION}.tar.gz | tar -xz --strip-components 1
 ADD patches patches
 RUN patch -p1 < patches/udp-proxy-fly-global-services.patch
 RUN patch -p1 < patches/kcp-quic-fly-global-services.patch
-RUN CGO_ENABLED=0 go install ./cmd/frps
+
+RUN cd web/frps && npm install && npm run build
+RUN make frps
 
 FROM alpine:latest
 WORKDIR app
-COPY --from=build /go/bin/frps .
+COPY --from=build /go/frp/bin/frps .
 COPY frps.toml .
 CMD ["/app/frps","-c","/app/frps.toml"]


### PR DESCRIPTION
frp v0.67.0+ introduced a major web UI update that requires Node.js and npm during compilation. This commit updates the Dockerfile to support compatibility with these newer versions.